### PR TITLE
Update zip code for Edmond, OK

### DIFF
--- a/data/zipcodes.csv
+++ b/data/zipcodes.csv
@@ -32522,7 +32522,7 @@
 "73009","Binger","OK"
 "73010","Blanchard","OK"
 "73011","Bradley","OK"
-"73012","Bray","OK"
+"73012","Edmond","OK"
 "73013","Edmond","OK"
 "73014","Calumet","OK"
 "73015","Carnegie","OK"


### PR DESCRIPTION
**Problem:**

From Carrie at Oklahoma City University: 

I downloaded reports from our recent giving day and I?m seen about 10 instances of a particular error. Donors who live in Edmond, Oklahoma, 73012 are listed in the report as living in Bray, Oklahoma, which is about 100 miles away!
 
I did a little Googling and this says Bray used to have that zip code but no longer does. https://en.wikipedia.org/wiki/Bray,_Oklahoma
 
Would you please update your system so this error no longer occurs?

Sounds like whatever we're using to infer city from zip needs to be updated. Is that something we control or an off the shelf plugin?

**Ticket**

https://app.asana.com/0/1172077698943204/1200330729079797/f

**Solution**

Update the city for zip code `73012`, from `Bray` to `Edmond`