### PR TITLE
Fix singular zipcode (06825)

### DIFF
--- a/data/zipcodes.csv
+++ b/data/zipcodes.csv
@@ -2640,7 +2640,7 @@
 "06819","Danbury","CT"
 "06820","Darien","CT"
 "06824","Fairfield","CT"
-"06825","Bridgeport","CT"
+"06825","Fairfield","CT"
 "06829","Georgetown","CT"
 "06830","Greenwich","CT"
 "06831","Greenwich","CT"

--- a/lib/area/version.rb
+++ b/lib/area/version.rb
@@ -1,3 +1,3 @@
 module Area
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
### Scope
Fix the "06825" zipcode to be "Fairfield" and not "Bridgeport".